### PR TITLE
Progress bars & restore refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Set to number of hours between full backups. Note: This does perform the actuall
 
 ### Different MySQL data directory
 
-The default directory for MySQL is normally `/var/lib/mysql`. If you have mounted a volume for your data and set different [`datadir`](https://dev.mysql.com/doc/refman/8.0/en/data-directory.html) you can pass in the following option: `-mysql-data-dir=/mnt/my_mysql_volume/mysql` or set the `"mysql_data_path"` config property in the JSON config.
+The default directory for MySQL is normally `/var/lib/mysql`. If you have mounted a volume for your data and set different [`datadir`](https://dev.mysql.com/doc/refman/8.0/en/data-directory.html) you can pass in the following option: `-mysql-data-path=/mnt/my_mysql_volume/mysql` or set the `"mysql_data_path"` config property in the JSON config.
 
 ### Persistent storage directory
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ really-simple-db-backup download -hostname my-other-host
 If you have run the `download` command and have a fully prepared backup that you now wish to use, you can run the `finalize-restore` command which will run the second half of steps that are run by the `restore` command.
 
 ```shell
-really-simple-db-backup finalize-restore -existing-restore-directory-flag=/mnt/my_restore_volume/really-simple-db-restore
+really-simple-db-backup finalize-restore -existing-restore-directory=/mnt/my_restore_volume/really-simple-db-restore
 ```
 
 **Note**

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Set to run 05:00 AM every day.
 ```
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-0 5 * * * /usr/bin/really-simple-db-backup perform
+0 5 * * * /usr/bin/really-simple-db-backup perform > /dev/null
 ```
 
 #### For hourly backups
@@ -51,7 +51,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 ```
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-1 * * * * /usr/bin/really-simple-db-backup perform
+1 * * * * /usr/bin/really-simple-db-backup perform > /dev/null
 ```
 
 ### Available commands

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -169,7 +169,7 @@ func Begin(cliArgs []string) {
 			*timestampFlag,
 			configStruct.DOSpaceName,
 			*existingVolumeIDFlag,
-			*existingBackupDirectoryFlag,
+			*existingRestoreDirectoryFlag,
 			digitalOceanClient,
 			minioClient,
 		)

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -32,13 +32,14 @@ func Begin(cliArgs []string) {
 	args := cliArgs[1:]
 
 	if len(args) == 0 {
-		pkg.ErrorLog.Printf("Usage:\n%s perform|perform-full|perform-incremental|restore|upload|test-alert|list-backups|prune [flags]\n\n", os.Args[0])
+		pkg.ErrorLog.Printf("Usage:\n%s perform|perform-full|perform-incremental|upload|restore|download|finalize-restore|test-alert|list-backups|prune [flags]\n\n", os.Args[0])
 		os.Exit(1)
 	}
 
 	uploadFileFlag := flag.String("upload-file", "", "[upload] File to upload to bucket")
 	existingVolumeIDFlag := flag.String("existing-volume-id", "", "Existing volume ID")
 	existingBackupDirectoryFlag := flag.String("existing-backup-directory", "", "Existing backup directory")
+	existingRestoreDirectoryFlag := flag.String("existing-restore-directory", "", "Existing restore directory")
 	hostnameFlag := flag.String("hostname", "", "Hostname of backups to list")
 	timestampFlag := flag.String("timestamp", "", "List backups since timestamp. Should be in format YYYYMMDDHHII")
 	verboseFlag := flag.Bool("v", false, "Verbose logging")
@@ -117,16 +118,78 @@ func Begin(cliArgs []string) {
 			fromHostname = *hostnameFlag
 		}
 
-		err = backupMysqlPerformRestore(
+		mysqlDataPath := configStruct.MysqlDataPath
+
+		// Make sure MySQL data path exists
+		if _, fileErr := os.Stat(mysqlDataPath); fileErr != nil {
+			// It did not exist, just to be sure we try to create it. If that fails this script can't continue
+			if os.IsNotExist(fileErr) {
+				err = os.MkdirAll(mysqlDataPath, 0700)
+				if err != nil {
+					pkg.ErrorLog.Fatalln("Could not access nor create the MySQL data path")
+				}
+			} else {
+				pkg.ErrorLog.Fatalln("Could not access the MySQL data path")
+			}
+		}
+
+		var restoreDirectory string
+		var mountDirectory string
+		var volume *godo.Volume
+		restoreDirectory, mountDirectory, volume, err = backupMysqlDownloadAndPrepare(
 			fromHostname,
 			*timestampFlag,
 			configStruct.DOSpaceName,
-			configStruct.MysqlDataPath,
 			*existingVolumeIDFlag,
 			*existingBackupDirectoryFlag,
 			digitalOceanClient,
 			minioClient,
 		)
+
+		if err == nil {
+			err = backupMysqlFinalizeRestore(
+				restoreDirectory,
+				configStruct.MysqlDataPath,
+				mountDirectory,
+				volume,
+				digitalOceanClient,
+				minioClient,
+			)
+		}
+	case "download":
+		fromHostname := hostname
+		if *hostnameFlag != "" {
+			fromHostname = *hostnameFlag
+		}
+
+		var restoreDirectory string
+
+		restoreDirectory, _, _, err = backupMysqlDownloadAndPrepare(
+			fromHostname,
+			*timestampFlag,
+			configStruct.DOSpaceName,
+			*existingVolumeIDFlag,
+			*existingBackupDirectoryFlag,
+			digitalOceanClient,
+			minioClient,
+		)
+
+		if err == nil {
+			pkg.Log.Printf("Downloaded complete. Directory: %s\n", restoreDirectory)
+		}
+	case "finalize-restore":
+		err = backupMysqlFinalizeRestore(
+			*existingRestoreDirectoryFlag,
+			configStruct.MysqlDataPath,
+			"",
+			nil,
+			digitalOceanClient,
+			minioClient,
+		)
+
+		if err == nil {
+			pkg.Log.Printf("Restore complete. Don't forget to cleanup manually!")
+		}
 	case "upload":
 		if *uploadFileFlag == "" {
 			pkg.ErrorLog.Fatalln("-upload-file parameter required for `upload` command.")
@@ -219,9 +282,9 @@ func Begin(cliArgs []string) {
 func pluralize(count int, singular string, plural string) string {
 	if count == 1 {
 		return singular
-	} else {
-		return plural
 	}
+
+	return plural
 }
 
 func backupCleanup(volume *godo.Volume, mountDirectory string, digitalOceanClient *pkg.DigitalOceanClient) error {

--- a/cmd/backup_restore.go
+++ b/cmd/backup_restore.go
@@ -134,6 +134,7 @@ func backupMysqlPerformRestore(fromHostname string, restoreTimestamp string, bac
 		"--target-dir",
 		restoreDirectory,
 	)
+
 	if err != nil {
 		pkg.AlertError(configStruct.Alerting, "Could not create backup.", err)
 		return backupCleanup(volume, mountDirectory, digitalOceanClient)
@@ -141,16 +142,6 @@ func backupMysqlPerformRestore(fromHostname string, restoreTimestamp string, bac
 
 	pkg.Log.Println("Prepare completed! Putting files back")
 	pkg.Log.Println("Warning: Removing everything in the MySQL data directory")
-
-	_, err = pkg.PerformCommand("find", restoreDirectory, "-name", "*.xbstream", "-exec", "rm {} \\;")
-	if err != nil {
-		pkg.AlertError(configStruct.Alerting, "Could not delete leftover .xbstream files. Continuing anyway. It may take more space than expected, but might work", err)
-	}
-
-	_, err = pkg.PerformCommand("find", restoreDirectory, "-name", "*.qb", "-exec", "rm {} \\;")
-	if err != nil {
-		pkg.AlertError(configStruct.Alerting, "Could not delete leftover .qb files. Continuing anyway. It may take more space than expected, but might work", err)
-	}
 
 	// We try to run this command. If it fails, we just run xtrabackup --copy-back anyway.
 	// It will error if the directory is not empty

--- a/cmd/backup_restore.go
+++ b/cmd/backup_restore.go
@@ -196,7 +196,9 @@ func downloadBackups(backups []backupItem, restoreDirectory string, bucketName s
 			return err
 		}
 
-		progressBar := pb.New(int(size)).SetUnits(pb.U_BYTES)
+		progressBar := pb.New(int(size))
+		progressBar.SetUnits(pb.U_BYTES)
+		progressBar.ShowSpeed = true
 		progressReader := progressBar.NewProxyReader(reader)
 
 		progressBar.Start()

--- a/cmd/backup_restore.go
+++ b/cmd/backup_restore.go
@@ -69,7 +69,7 @@ func backupMysqlDownloadAndPrepare(
 
 	// - Create & mount volume to house backup
 	sizeInGigaBytes := bytesToGigaBytes(totalSizeInBytes)
-	aDecentSizeInGigaBytes := sizeInGigaBytes * 10
+	aDecentSizeInGigaBytes := sizeInGigaBytes * 5
 
 	var volume *godo.Volume
 	var mountDirectory string
@@ -191,6 +191,8 @@ func downloadBackups(backups []backupItem, restoreDirectory string, bucketName s
 
 		progressBar := pb.New(int(size)).SetUnits(pb.U_BYTES)
 		progressReader := progressBar.NewProxyReader(reader)
+
+		progressBar.Start()
 
 		err = decompressBackupFile(progressReader, restoreDirectory, numberOfCPUs)
 

--- a/cmd/backup_restore.go
+++ b/cmd/backup_restore.go
@@ -147,12 +147,17 @@ func backupMysqlPerformRestore(fromHostname string, restoreTimestamp string, bac
 	// It will error if the directory is not empty
 	pkg.PerformCommand("mv", mysqlDataPath, "/tmp/")
 
+	copyCompleted := pkg.ReportProgressOnDirectoryCopy(restoreDirectory, mysqlDataPath)
+
 	// - Move to MySQL data directory
 	_, err = pkg.PerformCommand("xtrabackup", "--copy-back", "--target-dir", restoreDirectory)
 	if err != nil {
+		copyCompleted()
 		pkg.AlertError(configStruct.Alerting, "Could not copy back data files.", err)
 		return err
 	}
+
+	copyCompleted()
 
 	pkg.Log.Println("Last step: Set correct permissions on backup files")
 

--- a/pkg/object_storage_helper.go
+++ b/pkg/object_storage_helper.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/cheggaaa/pb"
-	"github.com/minio/minio-go"
+	minio "github.com/minio/minio-go"
 )
 
 // UploadFileToBucket uploads a file to a DigitalOcean bucket
@@ -15,6 +15,8 @@ func UploadFileToBucket(bucketName string, objectName string, filePath string, m
 	}
 
 	progress := pb.New64(stat.Size())
+	progress.SetUnits(pb.U_BYTES)
+	progress.ShowSpeed = true
 	progress.Start()
 
 	_, err = minioClient.FPutObject(bucketName, objectName, filePath, minio.PutObjectOptions{

--- a/pkg/progress_reporter.go
+++ b/pkg/progress_reporter.go
@@ -1,26 +1,38 @@
 package pkg
 
 import (
-	"os"
 	"time"
 
 	"github.com/cheggaaa/pb"
 )
 
+const progressBarRecheckTime = 5
+
 // ReportProgressOnFileSize will start printing the size of a file in relation to what the expected size is
 func ReportProgressOnFileSize(location string, expectedSize int64) func() {
 	bar := pb.StartNew(int(expectedSize))
 	closed := true
+
 	for !closed {
-		stat, err := os.Stat(location)
+		size, err := FileOrDirSize(location)
 		if err == nil {
-			bar.Set(int(stat.Size()))
+			bar.Set(int(size))
 		}
 
-		time.Sleep(1 * time.Second)
+		time.Sleep(progressBarRecheckTime * time.Second)
 	}
 
 	return func() {
 		closed = true
 	}
+}
+
+// ReportProgressOnDirectoryCopy will start printing the size of a directory in relation to another file
+func ReportProgressOnDirectoryCopy(sourceDirectory string, destinationDirectory string) func() {
+	sourceSize, err := DirSize(destinationDirectory)
+	if err != nil {
+		return func() {}
+	}
+
+	return ReportProgressOnFileSize(destinationDirectory, sourceSize)
 }

--- a/pkg/progress_reporter.go
+++ b/pkg/progress_reporter.go
@@ -12,6 +12,7 @@ const progressBarRecheckTime = 1
 func ReportProgressOnFileSize(location string, expectedSize int64, doneChan chan bool) {
 	bar := pb.StartNew(int(expectedSize))
 	bar.SetUnits(pb.U_BYTES)
+	bar.ShowSpeed = true
 	closed := false
 
 	go func() {

--- a/pkg/progress_reporter.go
+++ b/pkg/progress_reporter.go
@@ -27,12 +27,13 @@ func ReportProgressOnFileSize(location string, expectedSize int64) func() {
 	}
 }
 
-// ReportProgressOnDirectoryCopy will start printing the size of a directory in relation to another file
-func ReportProgressOnDirectoryCopy(sourceDirectory string, destinationDirectory string) func() {
-	sourceSize, err := DirSize(destinationDirectory)
+// ReportProgressOnCopy will start printing the size of a file/directory in relation to another file/directory
+// If source file/directory does not exist it will return immediately
+func ReportProgressOnCopy(source string, destination string) func() {
+	sourceSize, err := FileOrDirSize(source)
 	if err != nil {
 		return func() {}
 	}
 
-	return ReportProgressOnFileSize(destinationDirectory, sourceSize)
+	return ReportProgressOnFileSize(destination, sourceSize)
 }

--- a/pkg/progress_reporter.go
+++ b/pkg/progress_reporter.go
@@ -1,0 +1,26 @@
+package pkg
+
+import (
+	"os"
+	"time"
+
+	"github.com/cheggaaa/pb"
+)
+
+// ReportProgressOnFileSize will start printing the size of a file in relation to what the expected size is
+func ReportProgressOnFileSize(location string, expectedSize int64) func() {
+	bar := pb.StartNew(int(expectedSize))
+	closed := true
+	for !closed {
+		stat, err := os.Stat(location)
+		if err == nil {
+			bar.Set(int(stat.Size()))
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return func() {
+		closed = true
+	}
+}

--- a/pkg/system_helpers.go
+++ b/pkg/system_helpers.go
@@ -5,6 +5,20 @@ import (
 	"path/filepath"
 )
 
+// FileOrDirSize gets the size of a directory or file
+func FileOrDirSize(path string) (int64, error) {
+	fileStat, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+
+	if fileStat.IsDir() {
+		return DirSize(path)
+	}
+
+	return fileStat.Size(), nil
+}
+
 // DirSize get size of directory
 func DirSize(path string) (int64, error) {
 	var size int64


### PR DESCRIPTION
I made some changes to how the backups are downloaded, extracted and decompressed to be able to attach progress listeners to them. Hence my pull request before I'm done with all progress bars.

- [x] Adds a `download` and `finalize-restore` command to manually run the two major steps of restore
- [x] Change so backups are downloaded and immediately streamed into the extract software. Before it was 1. download xbstream to single file 2. run `xbstream -x -C` to extract files from archive 3. Decompress all files. Step 1 and 2 are now in one. In my mind it should run faster
- [x] Add a progressbar for the above step (downloaded)
- [x] With the changes above we can safely reduce the added overhead of the restore volume. Now it's `backupfile.size × 5` instead of `backupfile × 10`
- [x] Improve documentation a bit by cleaning up some steps, preferring the config JSON file approach over command line flags, etc
- [x] Add a progress bar for when moving restored and prepared datafiles from restore volume to mysql data path (implemented not tested)
- [x] Add average speed to progress bars across the board (super cool)